### PR TITLE
Bump MSRV to 1.58

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.56
+          toolchain: 1.58
           override: true
       - name: Run build
         uses: actions-rs/cargo@v1
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: 1.56
+            toolchain: 1.68
             components: clippy
             override: true
       - uses: actions-rs/clippy-check@v1
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: 1.56
+            toolchain: 1.68
             components: rustfmt
             override: true
       - run: cargo fmt -- --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+ * Bump MSRV to 1.58
+
 ## [0.2.0] - 2022-12-01
 
 ### Added


### PR DESCRIPTION
Needed due to a dependency which now requires at least 1.58. Also run clippy and rustfmt jobs with the current Rust version.